### PR TITLE
Update docs to show search and query limitations

### DIFF
--- a/docs/lightning/04-salesforce-lambdas/01-contact-flow-salesforce-lambdas.md
+++ b/docs/lightning/04-salesforce-lambdas/01-contact-flow-salesforce-lambdas.md
@@ -252,7 +252,13 @@ This operation returns a response of:
     ],
     "sf_count": 1
 }
+
 ```
+
+Due to the `sf_records` value being a complex object, 
+the query oparation function cannot be used from directly within a contact flow. 
+See, [https://docs.aws.amazon.com/connect/latest/adminguide/connect-lambda-functions.html#verify-function](Amazon Connect Administrator Guide)
+for futher details.
 
 
 ### Salesforce queryOne
@@ -468,6 +474,11 @@ The operation returns a response of:
     "sf_count": 3
 }
 ```
+
+Due to the `sf_records` value being a complex object, 
+the search function cannot be used from directly within a contact flow. 
+See, [https://docs.aws.amazon.com/connect/latest/adminguide/connect-lambda-functions.html#verify-function](Amazon Connect Administrator Guide)
+for futher details.
 
 ### Salesforce searchOne
 


### PR DESCRIPTION
*Issue #, if available:*

When search/query is the `sf_operation` on the `sfInvokeApi`, the error `Results": "The Lambda Function Returned An Error."` can be seen in the Connect Flow Logs. This is due to the returned object being "complex" rather than a simple string map as per the [Amazon Connect Documentation.](https://docs.aws.amazon.com/connect/latest/adminguide/connect-lambda-functions.html#verify-function) 

*Description of changes:*

This Pull Request updates the documentation of the Salesforce Lambdas to call this out clearly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
