### PR TITLE
fix Voice Id setting page.

### DIFF
--- a/docs/lightning/03-cti-adapter/13-voice-id.md
+++ b/docs/lightning/03-cti-adapter/13-voice-id.md
@@ -38,5 +38,5 @@ Add the Voice Id component to the contacts page:
 Add the Voice Id component to the Task/Cases page:
 1. Open the task record page, and Edit Page (same steps as Contacts).
 2. Find `ac_VoiceIdChannelDetailView` in the custom components list, drag and drop it into the page.
-3. Save and return to the record page. Click activate and assign as Org Default if prompted.
+3. Save and return to the record page. Click activate and assign as App Default if prompted.
 <img src={useBaseUrl('/img/shared/voiceid6.png')} />


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*

I set an `ac_VoiceIdChannelDetailView` component, but it didn't show up in my Service Console page.
I assign as App Default on Activate setting popup, then it show.
So I think select "App Default" better than "Org Default".
