### PR TITLE
fix minor typo, "SOLS" to "SOSL"

### DIFF
--- a/docs/classic/04-salesforce-lambdas/01-contact-flow-salesforce-lambdas.md
+++ b/docs/classic/04-salesforce-lambdas/01-contact-flow-salesforce-lambdas.md
@@ -153,7 +153,7 @@ This operation is invoked by setting "sf_operation" to "phoneLookup". In
 this case, the Lambda function queries Salesforce for Contacts based on
 the parameter passed to it.
 
-It uses the Salesforce Object Search Language (SOLS) to construct
+It uses the Salesforce Object Search Language (SOSL) to construct
 text-based search queries against the search index, which gives
 significant performance improvement when searching phone number fields.
 

--- a/docs/lightning/04-salesforce-lambdas/01-contact-flow-salesforce-lambdas.md
+++ b/docs/lightning/04-salesforce-lambdas/01-contact-flow-salesforce-lambdas.md
@@ -20,7 +20,7 @@ org:
 -   **Update:** updates a Salesforce object based on the parameters
     passed to it
 
--   **Phone Lookup:** uses Salesforce Object Search Language (SOLS) to
+-   **Phone Lookup:** uses Salesforce Object Search Language (SOSL) to
     construct text-based search queries against the search index, which
     gives significant performance improvement when searching phone
     number fields.
@@ -185,7 +185,7 @@ The "204" status indicates a success.
 
 This operation is invoked by setting **sf_operation** to
 **phoneLookup**. In this case, the Lambda function uses Salesforce
-Object Search Language (SOLS) to construct text-based search queries.
+Object Search Language (SOSL) to construct text-based search queries.
 For phoneLookup, the following parameters are required:
 
 -   sf_phone


### PR DESCRIPTION
*Description of changes:*
An abbreviation for "Salesforce Object Search Language" is "SOSL".
https://developer.salesforce.com/docs/atlas.en-us.234.0.soql_sosl.meta/soql_sosl/sforce_api_calls_sosl.htm

