### PR TITLE
Add workaround to `Reset My Security Token`

### DIFF
--- a/docs/lightning/02-installation/02-guided-setup.md
+++ b/docs/lightning/02-installation/02-guided-setup.md
@@ -400,6 +400,14 @@ It is a common practice to create an API user account for this purpose.
 32. In the **Quick Find** field, type **security** then select **Reset
     My Security Token** from the results
 
+    - If the menu does not appear, refer to [this](https://help.salesforce.com/s/articleView?id=000331668&type=1) document.
+
+    - If the problem persists, go to the following URL. (unofficial)
+
+        - Production: https://login.salesforce.com/_ui/system/security/ResetApiTokenEdit
+
+        - Sandbox: https://test.salesforce.com/_ui/system/security/ResetApiTokenEdit
+
 <img src={useBaseUrl('/img/lightning/image71.png')} />
 
 33. Select **Reset Security Token**. Your security token will be emailed


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Added workaround for when the menu is not displayed.

ref: https://salesforce.stackexchange.com/questions/197005/unable-to-see-the-reset-security-token-in-my-salesforce-org

<img width="750" alt="image" src="https://user-images.githubusercontent.com/20282867/183278656-7b4d71f8-baff-45c5-91e3-1afd51e2f2a4.png">

I also tried to generate a PDF, but it gave me an error on my macbook.

```
$ npm run build-pdf

> amazon-connect-salesforce-cti@1.0.0 build-pdf
> docusaurus build && docusaurus-pdf from-build build/ docs/lightning/notices /amazon-connect-salesforce-cti/ --output-file pdf/lightning.pdf && docusaurus-pdf from-build build/ docs/classic/notices /amazon-connect-salesforce-cti/ --output-file pdf/classic.pdf

Docusaurus config validation warning. Field "url": the url is not supposed to contain a sub-path like '/amazon-connect-salesforce-cti/', please use the baseUrl field for sub-paths

[en] Creating an optimized production build...
Docusaurus config validation warning. Field "url": the url is not supposed to contain a sub-path like '/amazon-connect-salesforce-cti/', please use the baseUrl field for sub-paths
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating

✔ Client
  

✔ Server
  Compiled successfully in 7.93s

warn Docusaurus found broken links!

Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.

Exhaustive list of all broken links found:

- On source page path = /amazon-connect-salesforce-cti/docs/lightning/cti-adapter/06-set-agent-status-on-session-end:
   -> linking to /amazon-connect-salesforce-cti/docs/lightning/installation/01-installing-package-from-appexchange

Success! Generated static files in "build".

Use `npm run serve` command to test your build locally.


Retrieving html from http://127.0.0.1:49792/amazon-connect-salesforce-cti/docs/lightning/notices/

Error: The src attribute of the 'styles*.js' file could not be found!
    at getScriptPathFromHTML (/Users/tkhs/tkhs/repos/amazon-connect-salesforce-cti/node_modules/@bojl/docusaurus-pdf/lib/index.js:66:15)
    at /Users/tkhs/tkhs/repos/amazon-connect-salesforce-cti/node_modules/@bojl/docusaurus-pdf/lib/index.js:144:46
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```