### PR TITLE
Update version header and compatibility tables to v5.31

### DIFF
--- a/docs/classic/02-installation/04-salesforce-lambdas-manual-setup.md
+++ b/docs/classic/02-installation/04-salesforce-lambdas-manual-setup.md
@@ -315,6 +315,10 @@ listed (ex. v5.21.1), it will be grouped with with its major version unless othe
     <th>Lambda Version</th>
   </tr>
   <tr>
+    <td>v5.31</td>
+    <td>v5.22 - v5.24</td>
+  </tr>
+  <tr>
     <td>v5.29</td>
     <td>v5.22 - v5.24</td>
   </tr>

--- a/docs/lightning/02-installation/04-salesforce-lambdas-manual-setup.md
+++ b/docs/lightning/02-installation/04-salesforce-lambdas-manual-setup.md
@@ -394,6 +394,10 @@ listed (ex. v5.21.1), it will be grouped with with its major version unless othe
     <th>Lambda Version</th>
   </tr>
   <tr>
+    <td>v5.31</td>
+    <td>v5.22 - v5.24</td>
+  </tr>
+  <tr>
     <td>v5.29</td>
     <td>v5.22 - v5.24</td>
   </tr>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,7 +10,7 @@ module.exports = {
   projectName: 'amazon-connect-salesforce-cti',
   themeConfig: {
     navbar: {
-      title: 'v5.29',
+      title: 'v5.31',
       logo: {
         src: 'img/logo.svg',
       },


### PR DESCRIPTION
The navbar title and lambda compatibility tables were still referencing v5.29 after the v5.31 release notes were merged.


