### PR TITLE
docs: Add post-setup cleanup guidance for sfExecuteAWSService Lambda

### DIFF
--- a/docs/classic/02-installation/01-installation.md
+++ b/docs/classic/02-installation/01-installation.md
@@ -196,4 +196,12 @@ Before you create the ExecuteAwsService Named Credential, **confirm that the app
 
 9. Click **Save**.
 
+#### Post-Setup Cleanup (Recommended)
+
+The `sfExecuteAWSService` Lambda function is used only during initial setup to configure your Amazon Connect instance and related AWS resources. Once your CTI Adapter configuration is complete, this function is no longer needed for day-to-day operations.
+
+As a best practice, we recommend **disabling or deleting** the `sfExecuteAWSService` Lambda function and its associated IAM user (e.g., `sfExecuteAwsServiceIamUser`) to keep your environment clean and minimize unused resources.
+
+**Note:** If you need to re-run the Guided Setup wizard in the future, you can re-deploy the Lambda package from the AWS Serverless Application Repository.
+
 After following the above instructions, follow [these instructions](/docs/classic/installation/02-guided-setup) to navigate to the Guided Setup feature.

--- a/docs/classic/02-installation/02-guided-setup.md
+++ b/docs/classic/02-installation/02-guided-setup.md
@@ -438,3 +438,11 @@ retrieve secrets.
 29. Select the secret you just created, and copy the Secret ARN
 
 <img src={useBaseUrl('/img/lightning/image77.png')} />
+
+### Post-Setup Cleanup (Recommended)
+
+The `sfExecuteAWSService` Lambda function is used only during initial setup to configure your Amazon Connect instance and related AWS resources. Once your CTI Adapter configuration is complete, this function is no longer needed for day-to-day operations.
+
+As a best practice, we recommend **disabling or deleting** the `sfExecuteAWSService` Lambda function and its associated IAM user (e.g., `sfExecuteAwsServiceIamUser`) to keep your environment clean and minimize unused resources.
+
+**Note:** If you need to re-run the Guided Setup wizard in the future, you can re-deploy the Lambda package from the AWS Serverless Application Repository.

--- a/docs/lightning/02-installation/01-installation.md
+++ b/docs/lightning/02-installation/01-installation.md
@@ -196,4 +196,12 @@ Before you create the ExecuteAwsService Named Credential, **confirm that the app
 
 9. Click **Save**.
 
+#### Post-Setup Cleanup (Recommended)
+
+The `sfExecuteAWSService` Lambda function is used only during initial setup to configure your Amazon Connect instance and related AWS resources. Once your CTI Adapter configuration is complete, this function is no longer needed for day-to-day operations.
+
+As a best practice, we recommend **disabling or deleting** the `sfExecuteAWSService` Lambda function and its associated IAM user (e.g., `sfExecuteAwsServiceIamUser`) to keep your environment clean and minimize unused resources.
+
+**Note:** If you need to re-run the Guided Setup wizard in the future, you can re-deploy the Lambda package from the AWS Serverless Application Repository.
+
 After following the above instructions, follow [these instructions](/docs/lightning/installation/02-guided-setup) to navigate to the Guided Setup feature.

--- a/docs/lightning/02-installation/02-guided-setup.md
+++ b/docs/lightning/02-installation/02-guided-setup.md
@@ -735,3 +735,11 @@ to invoke the function.
 
 7.  The AWS Lambda function has been added to your Amazon Connect
     instance.
+
+### Post-Setup Cleanup (Recommended)
+
+The `sfExecuteAWSService` Lambda function is used only during initial setup to configure your Amazon Connect instance and related AWS resources. Once your CTI Adapter configuration is complete, this function is no longer needed for day-to-day operations.
+
+As a best practice, we recommend **disabling or deleting** the `sfExecuteAWSService` Lambda function and its associated IAM user (e.g., `sfExecuteAwsServiceIamUser`) to keep your environment clean and minimize unused resources.
+
+**Note:** If you need to re-run the Guided Setup wizard in the future, you can re-deploy the Lambda package from the AWS Serverless Application Repository.


### PR DESCRIPTION
Add recommended guidance advising customers to disable or delete the sfExecuteAWSService Lambda function and its associated IAM user after initial CTI Adapter setup completes. This function is only needed during setup and is not required for day-to-day operations.

Added to both Lightning and Classic installation docs (01-installation and 02-guided-setup).

sim: https://taskei.amazon.dev/tasks/P427855637

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
